### PR TITLE
FIX: More specific regex to avoid match with <header> markup.

### DIFF
--- a/src/Extension/TagInserter.php
+++ b/src/Extension/TagInserter.php
@@ -41,11 +41,11 @@ class TagInserter extends Extension
         foreach ($combinedHTML as $k => $v) {
             switch ($k) {
                 case 'start-head':
-                    $html = preg_replace('#(<head[^>]*>)#i', '\\1' . $v, $html);
+                    $html = preg_replace('#(<head(>|\s[^>]*>))#i', '\\1' . $v, $html);
                     break;
 
                 case 'end-head':
-                    $html = preg_replace('#(</head)#i', $v . '\\1', $html);
+                    $html = preg_replace('#(<\/head(>|\s[^>]*>))#i', $v . '\\1', $html);
                     break;
 
                 case 'start-body':
@@ -53,7 +53,7 @@ class TagInserter extends Extension
                     break;
 
                 case 'end-body':
-                    $html = preg_replace('#(</body)#i', $v . '\\1', $html);
+                    $html = preg_replace('#(<\/body)#i', $v . '\\1', $html);
                     break;
 
                 default:


### PR DESCRIPTION
Regex clashes with `<header>` tag, this changes the match to be more specific.

![Screen Shot 2019-03-18 at 12 19 48 PM](https://user-images.githubusercontent.com/50590/54500640-8e646b80-4983-11e9-9a89-03e536c3f074.png)
![Screen Shot 2019-03-18 at 12 19 20 PM](https://user-images.githubusercontent.com/50590/54500643-96bca680-4983-11e9-978b-1fedb55e4ca6.png)
