### PR TITLE
BUGFIX regex for head tag matches header and inserts tags in the wrong place

### DIFF
--- a/src/Extension/TagInserter.php
+++ b/src/Extension/TagInserter.php
@@ -41,19 +41,19 @@ class TagInserter extends Extension
         foreach ($combinedHTML as $k => $v) {
             switch ($k) {
                 case 'start-head':
-                    $html = preg_replace('#(<head[^>]*>)#i', '\\1' . $v, $html);
+                    $html = preg_replace('#(<head(>+|[\s]+(.*)?>))#i', '\\1' . $v, $html);
                     break;
 
                 case 'end-head':
-                    $html = preg_replace('#(</head)#i', $v . '\\1', $html);
+                    $html = preg_replace('#(<\head(>+|[\s]+(.*)?>))#i', $v . '\\1', $html);
                     break;
 
                 case 'start-body':
-                    $html = preg_replace('#(<body[^>]*>)#i', '\\1' . $v, $html);
+                    $html = preg_replace('#(<body(>+|[\s]+(.*)?>))#i', '\\1' . $v, $html);
                     break;
 
                 case 'end-body':
-                    $html = preg_replace('#(</body)#i', $v . '\\1', $html);
+                    $html = preg_replace('#(<\body(>+|[\s]+(.*)?>))#i', $v . '\\1', $html);
                     break;
 
                 default:


### PR DESCRIPTION
Bug example: https://regex101.com/r/D9d12b/1

With fix: https://regex101.com/r/D9d12b/1/

## The fix

I've updated the regex to specifically target the tag its looking for. ie. `head` vs `header` and `body` vs `bodyrandom`.

I've also updated it to be more resilient so that if the user types HTML incorrectly it still has a chance of finding where it should inject the HTML.

eg.

- `<head >`
- `<head                           >`
- `<head>>>>>`
- `<head some-arrtibute="blah">`

The same goes for the head closing tag and body opening and closing tags.
