### PR TITLE
Add a pretty integration icon

### DIFF
--- a/src/Admin/TagManager.php
+++ b/src/Admin/TagManager.php
@@ -17,6 +17,8 @@ class TagManager extends ModelAdmin
 
     private static $url_segment = 'tagmanager';
 
+    private static $menu_icon_class = 'font-icon-database font-icon-integration';
+
     public function getEditForm($id = null, $fields = null)
     {
         $fields = parent::getEditForm();


### PR DESCRIPTION
This will add a pretty integration icon to the model admin.

![image](https://user-images.githubusercontent.com/1168676/60937612-1d2b3880-a325-11e9-8f18-f733f85d0103.png)

Depends on https://github.com/silverstripe/silverstripe-admin/pull/905

People running a version <4.5 will still get the DB icon.