### PR TITLE
Add Matomo snippet

### DIFF
--- a/src/SnippetProvider/MatomoSnippetProvider.php
+++ b/src/SnippetProvider/MatomoSnippetProvider.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace SilverStripe\TagManager\SnippetProvider;
+
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\TextField;
+use SilverStripe\TagManager\SnippetProvider;
+use SilverStripe\View\ArrayData;
+
+/**
+ * A snippet provider that lets you add Matomo JS
+ */
+class MatomoSnippetProvider implements SnippetProvider
+{
+
+    public function getTitle()
+    {
+        return "Matomo";
+    }
+
+    public function getParamFields()
+    {
+        return FieldList::create(
+            TextField::create(
+                'AnalyticsURL',
+                _t(static::class . '.AnalyticsURL', 'Analytics URL')
+            ),
+            TextField::create(
+                'SiteID',
+                _t(static::class . '.SiteID', 'Site ID')
+            ),
+            CheckboxField::create(
+                'DoNotTrack',
+                _t(static::class . 'DoNotTrack', 'Honor Do Not Track headers')
+            )->setDescription('https://en.wikipedia.org/wiki/Do_Not_Track'),
+            CheckboxField::create(
+                'DisableCookies',
+                _t(static::class . 'DisableCookies', 'Disable all tracking cookies')
+            )->setDescription('https://matomo.org/faq/general/faq_157/')
+        );
+    }
+
+    public function getSummary(array $params)
+    {
+        if (!empty($params['SiteID'])) {
+            return $this->getTitle() . " -  " . $params['SiteID'];
+        } else {
+            return $this->getTitle();
+        }
+    }
+
+    public function getSnippets(array $params)
+    {
+        if (empty($params['AnalyticsURL'])) {
+            throw new \InvalidArgumentException("Please supply your Analytics URL");
+        }
+        if (empty($params['SiteID'])) {
+            throw new \InvalidArgumentException("Please supply Site ID");
+        }
+
+        $dnt = false;
+        $cookies = true;
+
+        if (
+            !empty($params['DoNotTrack'])
+            && (bool)$params['DoNotTrack'] === true
+        ) {
+            $dnt = true;
+        }
+
+        if (
+            !empty($params['DisableCookies'])
+            && (bool)$params['DisableCookies'] === true
+        ) {
+            $cookies = false;
+        }
+
+        // Strip out any http/https
+        $url = preg_replace('#^[^:/.]*[:/]+#i', '', $params['AnalyticsURL']);
+        // Sanitise the ID
+        $site_id = preg_replace('[^A-Za-z0-9_\-]', '', $params['SiteID']);
+
+        $data = ArrayData::create([
+            'URL' => $url,
+            'SiteID' => $site_id,
+            'DoNotTrack' => $dnt,
+            'Cookies' => $cookies
+        ]);
+
+        $script = $data->renderWith(static::class . '_script');
+        $script = str_replace("\n", "", $script);
+
+        $noscript = $data->renderWith(static::class . '_noscript');
+        $noscript = str_replace("\n", "", $noscript);
+
+        return [
+            self::ZONE_HEAD_START => $script,
+            self::ZONE_BODY_END => $noscript
+        ];
+    }
+}

--- a/src/SnippetProvider/MatomoSnippetProvider.php
+++ b/src/SnippetProvider/MatomoSnippetProvider.php
@@ -82,8 +82,9 @@ class MatomoSnippetProvider implements SnippetProvider
             $cookies = false;
         }
 
-        // Strip out any http/https
+        // Strip out any http/https and remove trailing slashes
         $url = preg_replace('#^[^:/.]*[:/]+#i', '', $params['AnalyticsURL']);
+        $url = rtrim($url,"/");
         // Sanitise the ID
         $site_id = preg_replace('[^A-Za-z0-9_\-]', '', $params['SiteID']);
 

--- a/templates/SilverStripe/TagManager/SnippetProvider/MatomoSnippetProvider_noscript.ss
+++ b/templates/SilverStripe/TagManager/SnippetProvider/MatomoSnippetProvider_noscript.ss
@@ -1,0 +1,6 @@
+<noscript><img
+    referrerpolicy="no-referrer-when-downgrade"
+    src="//{$URL}/matomo.php?idsite={$SiteID}&amp;rec=1"
+    style="border:0;"
+    alt=""
+/></noscript>

--- a/templates/SilverStripe/TagManager/SnippetProvider/MatomoSnippetProvider_optout.ss
+++ b/templates/SilverStripe/TagManager/SnippetProvider/MatomoSnippetProvider_optout.ss
@@ -1,0 +1,2 @@
+<div id="matomo-opt-out"></div>
+<script src="//{$URL}/index.php?module=CoreAdminHome&action=optOutJS&language=auto&div=m-opt-out"></script>

--- a/templates/SilverStripe/TagManager/SnippetProvider/MatomoSnippetProvider_script.ss
+++ b/templates/SilverStripe/TagManager/SnippetProvider/MatomoSnippetProvider_script.ss
@@ -1,7 +1,7 @@
 <script>
+  var settings = {"showIntro":true,"divId":"matomo-opt-out","cookiePath":"","cookieDomain":"","cookieSameSite":"Lax","OptOutComplete":"Opt-out complete","snip":"snip"};
   var _paq = window._paq = window._paq || [];
-  
-  <% if $DoNotTrack %>_paq.push(["setDoNotTrack", true]);<% end_if %>
+
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
 

--- a/templates/SilverStripe/TagManager/SnippetProvider/MatomoSnippetProvider_script.ss
+++ b/templates/SilverStripe/TagManager/SnippetProvider/MatomoSnippetProvider_script.ss
@@ -1,0 +1,20 @@
+<script>
+  var _paq = window._paq = window._paq || [];
+  
+  <% if $DoNotTrack %>_paq.push(["setDoNotTrack", true]);<% end_if %>
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+
+  (function() {
+    var u='//{$URL}/';
+
+    <% if not $Cookies %>_paq.push(["disableCookies"]);<% end_if %>
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '{$SiteID}']);
+
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true;
+    g.src=u+'matomo.js';
+    s.parentNode.insertBefore(g,s);
+  })();
+</script>


### PR DESCRIPTION
Matomo (https://matomo.org/) is possibly one of the largest Open Source alternatives to Google Analytics and has many of the same features (and some extras as paid for plugins).

Matomo also far greater support for global data protection regulations, as it performs partial IP obfuscation and allows you to run the tracking JavaScript in a "Cookie free" mode (which offers reduced tracking but greater data privacy).

This snippet generates the standard embed JS for a site and also supports adding some additional features:

1. Globally disabling tracking cookies.
2. Adding an auto generated "Opt out" banner, that can be attached at the beginning of the end of the site's code.

I know there is some discussion over which snippets could/should be available for this module, but Matomo is a very mature and well maintained platform and a really good alternative to Google Analytics (for those of us who are sick of Google's BS regarding data tracking), so I am proposing it gets added support in the core?