### PR TITLE
Add TagInserter as an extension to RequestHandler

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,6 +1,6 @@
 ---
 Name: tagmanager
 ---
-SilverStripe\CMS\Controllers\ContentController:
+SilverStripe\Control\RequestHandler:
   extensions:
    - SilverStripe\TagManager\Extension\TagInserter


### PR DESCRIPTION
As per issue #20 by default, `TagInserter` only loads on extensions of `ContentController` and then also has some issues.

This PR moves `TagInserter` to instead extend `RequestHandler` which means it can be loaded on a lot more views.

A downside of this is that `TagInserter` will also be called in the admin and on `dev/tasks` and `dev/build`, so I have also added some configurable exclusions to ignore instances of certain classes.